### PR TITLE
GitHub action to validate PVCollada XML examples

### DIFF
--- a/.github/workflows/validate_xml_with_xsd.py
+++ b/.github/workflows/validate_xml_with_xsd.py
@@ -1,0 +1,21 @@
+import sys
+
+from lxml import etree
+
+
+if __name__ == '__main__':
+    assert len(sys.argv) == 3
+    xsd_filepath, xml_filepath = sys.argv[1], sys.argv[2]
+    with open(xsd_filepath, 'rb') as xsd:
+        schema_root = etree.XML(xsd.read())
+    with open(xml_filepath, 'rb') as xml:
+        xml_doc = etree.XML(xml.read())
+
+    schema = etree.XMLSchema(schema_root)
+    if schema.validate(xml_doc):
+        print('XML is valid.')
+    else:
+        print('! XML is invalid.')
+        for error in schema.error_log:
+            print(' -', error.message)
+        exit(1)

--- a/.github/workflows/validate_xml_with_xsd.yml
+++ b/.github/workflows/validate_xml_with_xsd.yml
@@ -1,0 +1,45 @@
+name: Validate PVCollada XML examples
+
+on:
+  push:
+    paths:
+      - pvcollada20_schema/pvcollada_schema_0.1.xsd
+      - pvcollada20_schema/collada_schema_1_5.xsd
+      - .github/workflows/validate_xml_with_xsd.py
+
+      - pvcollada20_schema/04 - TrackersPVC2_with_basic_electrical_layout_v2.pvc
+  pull_request:
+    paths:
+      - pvcollada20_schema/pvcollada_schema_0.1.xsd
+      - pvcollada20_schema/collada_schema_1_5.xsd
+      - .github/workflows/validate_xml_with_xsd.py
+
+      - pvcollada20_schema/04 - TrackersPVC2_with_basic_electrical_layout_v2.pvc
+  workflow_dispatch:
+
+jobs:
+  validate-schema:
+    strategy:
+      matrix:
+        xml_doc:
+          - pvcollada20_schema/04 - TrackersPVC2_with_basic_electrical_layout_v2.pvc
+    name: Validate XML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install lxml Python dependency
+        run: pip3 install lxml==5.3.1
+      - name: Checkout PVCollada and COLLADA schemas, the validation script, and the XML doc
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            pvcollada20_schema/pvcollada_schema_0.1.xsd
+            pvcollada20_schema/collada_schema_1_5.xsd
+            .github/workflows/validate_xml_with_xsd.py
+            ${{ matrix.xml_doc }}
+          sparse-checkout-cone-mode: false
+      - name: Run validation
+        run: python3 .github/workflows/validate_xml_with_xsd.py pvcollada20_schema/pvcollada_schema_0.1.xsd "${{ matrix.xml_doc }}"

--- a/pvcollada20_schema/pvcollada_schema_0.1.xsd
+++ b/pvcollada20_schema/pvcollada_schema_0.1.xsd
@@ -6,7 +6,7 @@
            xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
 
   <xs:import namespace="http://www.collada.org/2008/03/COLLADASchema"
-             schemaLocation="collada_schema_1_5.xsd"/>
+             schemaLocation="pvcollada20_schema/collada_schema_1_5.xsd"/>
 
   <xs:simpleType name="cell_type_enum" final="restriction" >
     <xs:restriction base="xs:string">


### PR DESCRIPTION
The GitHub action for validating the PVCollada XML examples with the PVCollada schema runs on push, pull request, or on demand through the GitHub website.
After a push or pull request event, the action only runs if PVCollada or Collada schemas were updated or if the example XML files listed in the GitHub action yaml file were updated.

In addition to validating the XML examples, the PVCollada schema is validated when the validation script parses it.