### PR TITLE
Adjust validation workflow to run in `pvcollada20_schema` directory

### DIFF
--- a/.github/workflows/validate_xml_with_xsd.yml
+++ b/.github/workflows/validate_xml_with_xsd.yml
@@ -42,4 +42,5 @@ jobs:
             ${{ matrix.xml_doc }}
           sparse-checkout-cone-mode: false
       - name: Run validation
-        run: python3 .github/workflows/validate_xml_with_xsd.py pvcollada20_schema/pvcollada_schema_0.1.xsd "${{ matrix.xml_doc }}"
+        working-directory: pvcollada20_schema
+        run: python3 "$GITHUB_WORKSPACE"/.github/workflows/validate_xml_with_xsd.py pvcollada_schema_0.1.xsd "$GITHUB_WORKSPACE"/"${{ matrix.xml_doc }}"

--- a/pvcollada20_schema/pvcollada_schema_0.1.xsd
+++ b/pvcollada20_schema/pvcollada_schema_0.1.xsd
@@ -6,7 +6,7 @@
            xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
 
   <xs:import namespace="http://www.collada.org/2008/03/COLLADASchema"
-             schemaLocation="pvcollada20_schema/collada_schema_1_5.xsd"/>
+             schemaLocation="collada_schema_1_5.xsd"/>
 
   <xs:simpleType name="cell_type_enum" final="restriction" >
     <xs:restriction base="xs:string">


### PR DESCRIPTION
PR #5 added a GitHub workflow for validating the example PVCollada XML documents, and updated the COLLADA schema import path in the PVCollada schema to be relative to the root directory of the repository. This PR reverts the change to the import path and updates the validation workflow to still run correctly.