### PR TITLE
Remove input layer

### DIFF
--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -158,169 +158,159 @@
 				<pv:circuit>
 					<!-- circuit_root tag => Always the parent of the tree -->
 					<pv:circuit_root>
-						<pv:input>
-							<!-- instance_transformer tag, in this case the transformer that will inject into the grid -->
-							<pv:instance_transformer url="#TransformerModel1" id="transformerInstance">
-								<!-- Cable between the transformer and the circuit_root -->
-								<pv:cable_to_parent url="#ACCableModel1" length="5" id="cableInstance1" />
-								<pv:inputs>
-									<pv:input>
-										<!-- instance_combiner_ac tag, the AC combiner that will combine the 3 strings -->
-										<pv:instance_combiner_ac url="#CombinerModel1" id="combinerInstance">
-											<!-- Cable between the AC combiner and the transformer -->
-											<pv:cable_to_parent url="#ACCableModel1" length="10" id="cableInstance2" />
-											<!-- inputs tag => the 3 inverters strings -->
-											<pv:inputs>
-												<pv:input>
-													<!-- Inverter #1 -->
-													<pv:instance_inverter url="#InverterModel1" id="inverterInstance1" name="Inverter #1">
-														<!-- Cable between the inverter and the AC combiner -->
-														<pv:cable_to_parent url="#ACCableModel1" length="10" id="cableInstance3" />
-														<!-- mppts tag -->
-														<pv:mppts>
-															<!-- mppt tag -->
-															<pv:mppt>
-																<!-- first string tag => the string connected to this mppt input -->
-																<pv:string id="string1">
-																	<pv:module_array>
-																		<pv:module_layout url="#rackId1">
-																			<!-- Cable between the string and the inverter -->
-																			<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance4" />
-																			<pv:position_in_string>1</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>1</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId1">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance5" />
-																			<pv:position_in_string>2</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>2</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId1">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance6" />
-																			<pv:position_in_string>3</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>3</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId1">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance7" />
-																			<!-- Cable between the string and the inverter -->
-																			<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance8" />
-																			<pv:position_in_string>4</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>4</pv:column>
-																		</pv:module_layout>
-																	</pv:module_array>
-																</pv:string>
-															</pv:mppt>
-														</pv:mppts>
-													</pv:instance_inverter>
-												</pv:input>
-												<pv:input>
-													<!-- Inverter #2 -->
-													<pv:instance_inverter url="#InverterModel1" id="inverterInstance2" name="Inverter #2">
-														<!-- Cable between the inverter and the AC combiner -->
-														<pv:cable_to_parent url="#ACCableModel1" length="11" id="cableInstance9" />
-														<!-- mppts tag -->
-														<pv:mppts>
-															<!-- mppt tag -->
-															<pv:mppt>
-																<!-- second string tag => the string connected to this mppt input -->
-																<pv:string id="string2">
-																	<pv:module_array>
-																		<pv:module_layout url="#rackId2">
-																			<!-- Cable between the string and the inverter -->
-																			<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance10" />
-																			<pv:position_in_string>1</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>1</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId2">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance11" />
-																			<pv:position_in_string>2</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>2</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId2">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance12" />
-																			<pv:position_in_string>3</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>3</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId2">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance13" />
-																			<!-- Cable between the string and the inverter -->
-																			<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance14" />
-																			<pv:position_in_string>4</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>4</pv:column>
-																		</pv:module_layout>
-																	</pv:module_array>
-																</pv:string>
-															</pv:mppt>
-														</pv:mppts>
-													</pv:instance_inverter>
-												</pv:input>
-												<pv:input>
-													<!-- Inverter #3 -->
-													<pv:instance_inverter url="#InverterModel1" id="inverterInstance3" name="Inverter #3">
-														<!-- Cable between the inverter and the AC combiner -->
-														<pv:cable_to_parent url="#ACCableModel1" length="12" id="cableInstance15" />
-														<!-- mppts tag -->
-														<pv:mppts>
-															<!-- mppt tag -->
-															<pv:mppt>
-																<!-- third string tag => the string connected to this mppt input -->
-																<pv:string id="string3">
-																	<pv:module_array>
-																		<pv:module_layout url="#rackId3">
-																			<!-- Cable between the string and the inverter -->
-																			<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance16" />
-																			<pv:position_in_string>1</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>1</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId3">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance17" />
-																			<pv:position_in_string>2</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>2</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId3">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance18" />
-																			<pv:position_in_string>3</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>3</pv:column>
-																		</pv:module_layout>
-																		<pv:module_layout url="#rackId3">
-																			<!-- Cable between the module and its neighbor in the string -->
-																			<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance19" />
-																			<!-- Cable between the string and the inverter -->
-																			<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance20" />
-																			<pv:position_in_string>4</pv:position_in_string>
-																			<pv:row>1</pv:row>
-																			<pv:column>4</pv:column>
-																		</pv:module_layout>
-																	</pv:module_array>
-																</pv:string>
-															</pv:mppt>
-														</pv:mppts>
-													</pv:instance_inverter>
-												</pv:input>
-											</pv:inputs>
-										</pv:instance_combiner_ac>
-									</pv:input>
-								</pv:inputs>
-							</pv:instance_transformer>
-						</pv:input>
+						<!-- instance_transformer tag, in this case the transformer that will inject into the grid -->
+						<pv:instance_transformer url="#TransformerModel1" id="transformerInstance">
+							<!-- Cable between the transformer and the circuit_root -->
+							<pv:cable_to_parent url="#ACCableModel1" length="5" id="cableInstance1" />
+							<pv:inputs>
+								<!-- instance_combiner_ac tag, the AC combiner that will combine the 3 strings -->
+								<pv:instance_combiner_ac url="#CombinerModel1" id="combinerInstance">
+									<!-- Cable between the AC combiner and the transformer -->
+									<pv:cable_to_parent url="#ACCableModel1" length="10" id="cableInstance2" />
+									<!-- inputs tag => the 3 inverters strings -->
+									<pv:inputs>
+										<!-- Inverter #1 -->
+										<pv:instance_inverter url="#InverterModel1" id="inverterInstance1" name="Inverter #1">
+											<!-- Cable between the inverter and the AC combiner -->
+											<pv:cable_to_parent url="#ACCableModel1" length="10" id="cableInstance3" />
+											<!-- mppts tag -->
+											<pv:mppts>
+												<!-- mppt tag -->
+												<pv:mppt>
+													<!-- first string tag => the string connected to this mppt input -->
+													<pv:string id="string1">
+														<pv:module_array>
+															<pv:module_layout url="#rackId1">
+																<!-- Cable between the string and the inverter -->
+																<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance4" />
+																<pv:position_in_string>1</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>1</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId1">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance5" />
+																<pv:position_in_string>2</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>2</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId1">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance6" />
+																<pv:position_in_string>3</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>3</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId1">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance7" />
+																<!-- Cable between the string and the inverter -->
+																<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance8" />
+																<pv:position_in_string>4</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>4</pv:column>
+															</pv:module_layout>
+														</pv:module_array>
+													</pv:string>
+												</pv:mppt>
+											</pv:mppts>
+										</pv:instance_inverter>
+										<!-- Inverter #2 -->
+										<pv:instance_inverter url="#InverterModel1" id="inverterInstance2" name="Inverter #2">
+											<!-- Cable between the inverter and the AC combiner -->
+											<pv:cable_to_parent url="#ACCableModel1" length="11" id="cableInstance9" />
+											<!-- mppts tag -->
+											<pv:mppts>
+												<!-- mppt tag -->
+												<pv:mppt>
+													<!-- second string tag => the string connected to this mppt input -->
+													<pv:string id="string2">
+														<pv:module_array>
+															<pv:module_layout url="#rackId2">
+																<!-- Cable between the string and the inverter -->
+																<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance10" />
+																<pv:position_in_string>1</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>1</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId2">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance11" />
+																<pv:position_in_string>2</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>2</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId2">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance12" />
+																<pv:position_in_string>3</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>3</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId2">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance13" />
+																<!-- Cable between the string and the inverter -->
+																<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance14" />
+																<pv:position_in_string>4</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>4</pv:column>
+															</pv:module_layout>
+														</pv:module_array>
+													</pv:string>
+												</pv:mppt>
+											</pv:mppts>
+										</pv:instance_inverter>
+										<!-- Inverter #3 -->
+										<pv:instance_inverter url="#InverterModel1" id="inverterInstance3" name="Inverter #3">
+											<!-- Cable between the inverter and the AC combiner -->
+											<pv:cable_to_parent url="#ACCableModel1" length="12" id="cableInstance15" />
+											<!-- mppts tag -->
+											<pv:mppts>
+												<!-- mppt tag -->
+												<pv:mppt>
+													<!-- third string tag => the string connected to this mppt input -->
+													<pv:string id="string3">
+														<pv:module_array>
+															<pv:module_layout url="#rackId3">
+																<!-- Cable between the string and the inverter -->
+																<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance16" />
+																<pv:position_in_string>1</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>1</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId3">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance17" />
+																<pv:position_in_string>2</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>2</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId3">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance18" />
+																<pv:position_in_string>3</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>3</pv:column>
+															</pv:module_layout>
+															<pv:module_layout url="#rackId3">
+																<!-- Cable between the module and its neighbor in the string -->
+																<pv:cable_to_neighbor url="#DCCableModel1" length="1" id="cableInstance19" />
+																<!-- Cable between the string and the inverter -->
+																<pv:cable_to_parent url="#DCCableModel1" length="3" id="cableInstance20" />
+																<pv:position_in_string>4</pv:position_in_string>
+																<pv:row>1</pv:row>
+																<pv:column>4</pv:column>
+															</pv:module_layout>
+														</pv:module_array>
+													</pv:string>
+												</pv:mppt>
+											</pv:mppts>
+										</pv:instance_inverter>
+									</pv:inputs>
+								</pv:instance_combiner_ac>
+							</pv:inputs>
+						</pv:instance_transformer>
 					</pv:circuit_root>
 				</pv:circuit>
 			</technique>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -484,16 +484,12 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
           <xs:documentation>Description of the upstream connection of the circuit root.</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="input" type="circuit_root_input_type"/>
+      <xs:choice>
+        <xs:element name="instance_transformer" type="instance_transformer_type" />
+        <xs:element name="instance_combiner_ac" type="instance_combiner_ac_type" />
+        <xs:element name="instance_inverter" type="instance_inverter_type" />
+      </xs:choice>
     </xs:sequence>
-  </xs:complexType>
-  <!-- Input for circuit_root element; it must have exactly one child chosen from the allowed instance types -->
-  <xs:complexType name="circuit_root_input_type">
-    <xs:choice minOccurs="1" maxOccurs="1">
-      <xs:element name="instance_transformer" type="instance_transformer_type" />
-      <xs:element name="instance_combiner_ac" type="instance_combiner_ac_type" />
-      <xs:element name="instance_inverter" type="instance_inverter_type" />
-    </xs:choice>
   </xs:complexType>
   <!-- Instance Transformer: requires a cable_to_parent and an inputs container -->
   <xs:complexType name="instance_transformer_type">
@@ -505,15 +501,9 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     <xs:attribute name="id" type="xs:ID" use="required" />
     <xs:attribute name="name" type="xs:string" use="optional" />
   </xs:complexType>
-  <!-- Inputs container for instance_transformer; each input must have exactly one instance child (transformer, AC combiner or inverter) -->
+  <!-- Inputs container for instance_transformer; each input must be either transformer, AC combiner or inverter -->
   <xs:complexType name="transformer_inputs_type">
-    <xs:sequence>
-      <xs:element name="input" type="transformer_input_type" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-  <!-- Input for instance_transformer/inputs elements; it must have exactly one child chosen from the allowed instance types -->
-  <xs:complexType name="transformer_input_type">
-    <xs:choice minOccurs="1" maxOccurs="1">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
       <xs:element name="instance_transformer" type="instance_transformer_type" />
       <xs:element name="instance_combiner_ac" type="instance_combiner_ac_type" />
       <xs:element name="instance_inverter" type="instance_inverter_type" />
@@ -529,15 +519,9 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     <xs:attribute name="id" type="xs:ID" use="required" />
     <xs:attribute name="name" type="xs:string" use="optional" />
   </xs:complexType>
-  <!-- Inputs container for instance_combiner_ac; each input must have exactly one instance child (transformer, AC combiner or inverter) -->
+  <!-- Inputs container for instance_combiner_ac; each input must must be either transformer, AC combiner or inverter) -->
   <xs:complexType name="combiner_ac_inputs_type">
-    <xs:sequence>
-      <xs:element name="input" type="combiner_ac_input_type" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-  <!-- Input for instance_combiner_ac/inputs elements; it must have exactly one child chosen from the allowed types -->
-  <xs:complexType name="combiner_ac_input_type">
-    <xs:choice minOccurs="1" maxOccurs="1">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
       <xs:element name="instance_transformer" type="instance_transformer_type" />
       <xs:element name="instance_combiner_ac" type="instance_combiner_ac_type" />
       <xs:element name="instance_inverter" type="instance_inverter_type" />
@@ -576,14 +560,8 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     <xs:attribute name="id" type="xs:ID" use="required" />
     <xs:attribute name="name" type="xs:string" use="optional" />
   </xs:complexType>
-  <!-- Inputs container for instance_combiner_Dc; each input must have exactly one instance child (DC combiner or string) -->
+  <!-- Inputs container for instance_combiner_Dc; each input must be either DC combiner or string) -->
   <xs:complexType name="combiner_dc_inputs_type">
-    <xs:sequence>
-      <xs:element name="input" type="combiner_dc_input_type" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-  <!-- Input for instance_combiner_dc/inputs elements; it must have exactly one child chosen from the allowed types -->
-  <xs:complexType name="combiner_dc_input_type">
     <xs:choice minOccurs="1" maxOccurs="unbounded">
       <xs:element name="instance_combiner_dc" type="instance_combiner_dc_type" />
       <xs:element name="string" type="string_type" />
@@ -610,16 +588,10 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     <xs:attribute name="name" type="xs:string" use="optional" />
     <xs:attribute name="id" type="xs:ID" use="required" />
   </xs:complexType>
-  <!-- Inputs container for instance_optimizer elements: It must appear exactly once and contain one or more 'input' children -->
+  <!-- Inputs container for instance_optimizer elements: It must appear exactly once and contain one or more 'module_layout' children -->
   <xs:complexType name="optimizer_inputs_type">
     <xs:sequence>
-      <xs:element name="input" type="optimizer_input_type" minOccurs="1" maxOccurs="unbounded" />
-    </xs:sequence>
-  </xs:complexType>
-  <!-- Input type for optimizer inputs: contains exactly one module_layout -->
-  <xs:complexType name="optimizer_input_type">
-    <xs:sequence>
-      <xs:element name="module_layout" type="module_layout_type" />
+      <xs:element name="module_layout" type="module_layout_type" minOccurs="1" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
   <!-- The "string" element must contain exactly one child which is either a module_array or an optimizer_array -->


### PR DESCRIPTION
Proposal to remove the `pv:input` layer.

It seems unnecessary, the inputs are already stored in `pv:inputs` element to distinguish them from other properties
Removing it will make the schema a little bit simpler.