### PR TITLE
Fixing automatic workflow

### DIFF
--- a/.github/workflows/validate_xml_with_xsd.yml
+++ b/.github/workflows/validate_xml_with_xsd.yml
@@ -6,6 +6,7 @@ on:
       - schema/pvcollada_schema_0.1.xsd
       - schema/collada_schema_1_5.xsd
       - .github/workflows/validate_xml_with_xsd.py
+      - .github/workflows/validate_xml_with_xsd.yml
 
       - Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
   pull_request:
@@ -13,6 +14,7 @@ on:
       - schema/pvcollada_schema_0.1.xsd
       - schema/collada_schema_1_5.xsd
       - .github/workflows/validate_xml_with_xsd.py
+      - .github/workflows/validate_xml_with_xsd.yml
 
       - Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
   workflow_dispatch:

--- a/.github/workflows/validate_xml_with_xsd.yml
+++ b/.github/workflows/validate_xml_with_xsd.yml
@@ -7,14 +7,14 @@ on:
       - schema/collada_schema_1_5.xsd
       - .github/workflows/validate_xml_with_xsd.py
 
-      - schema/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+      - Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
   pull_request:
     paths:
       - schema/pvcollada_schema_0.1.xsd
       - schema/collada_schema_1_5.xsd
       - .github/workflows/validate_xml_with_xsd.py
 
-      - schema/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+      - Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
   workflow_dispatch:
 
 jobs:
@@ -22,22 +22,22 @@ jobs:
     strategy:
       matrix:
         xml_doc:
-          - schema/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+          - Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
     name: Validate XML
     runs-on: ubuntu-latest
     steps:
       - name: Install Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install lxml Python dependency
         run: pip3 install lxml==5.3.1
       - name: Checkout PVCollada and COLLADA schemas, the validation script, and the XML doc
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
-            pvcollada20_schema/pvcollada_schema_0.1.xsd
-            pvcollada20_schema/collada_schema_1_5.xsd
+            schema/pvcollada_schema_0.1.xsd
+            schema/collada_schema_1_5.xsd
             .github/workflows/validate_xml_with_xsd.py
             ${{ matrix.xml_doc }}
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
**Note:** Path to schema and example is set up multiple times:
- path to files that trigger the workflow
- path to files that need to be checked out
- path to files to actually run the script

I think it could be improved so that the path is reused.
But I didn't invest time into refactoring the workflow.. Maybe later.