### PR TITLE
rename x_spacing to row_spacing, and rename y_spacing to column_spacing

### DIFF
--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -417,7 +417,7 @@
 					<!-- rack tag -->
 					<pv:rack>
 						<pv:row_spacing>20</pv:row_spacing>
-						<pv:row_spacing>20</pv:row_spacing>
+						<pv:column_spacing>20</pv:column_spacing>
 						<pv:module_rows>1</pv:module_rows>
 						<pv:module_columns>4</pv:module_columns>
 						<pv:module_orientation>portrait</pv:module_orientation>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -810,7 +810,7 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
             <xs:documentation>Spacing between modules in the row direction</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="y_spacing" type="collada:float_type">
+        <xs:element name="column_spacing" type="collada:float_type">
           <xs:annotation>
             <xs:documentation>Spacing between modules in the column direction</xs:documentation>
           </xs:annotation>


### PR DESCRIPTION
@stephane-pv please review. Defining x_spacing to be in the X-axis direction implies that the racks are aligned on the X-axis, which may not always be desired.