### PR TITLE
move lat, long, elev to COLLADA

### DIFF
--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -12,6 +12,11 @@
 		<modified>2024-06-06T13:32:31Z</modified>
 		<unit meter="0.01" name="cm" />
 		<up_axis>Z_UP</up_axis>
+		<geographic_location>
+			<latitude>46.2044</pv:latitude>
+			<longitude>6.1432</pv:longitude>
+			<altitude mode="absolute">375</pv:elevation>		  
+		</geographic_location>
 		<extra>
 			<technique profile="PVCollada-2.0">
 				<!-- software tag -->
@@ -25,9 +30,6 @@
 					<pv:drawing>Project drawing</pv:drawing>
 					<pv:company>Test company</pv:company>
 					<pv:country>CH</pv:country>
-					<pv:latitude>46.2044</pv:latitude>
-					<pv:longitude>6.1432</pv:longitude>
-					<pv:elevation>375</pv:elevation>
 					<pv:timezone>Europe/Zurich</pv:timezone>
 					<pv:timezone_offset>2</pv:timezone_offset>
 					<pv:geocoordinate_system>EPSG:4326</pv:geocoordinate_system>

--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -8,11 +8,13 @@
 			<author>PVsyst</author>
 			<comments>PVC 2.0 sample file : 1 terrain and 3 tables, all based on the same model. Electrical components and circuit (3 inverters, 1 AC combiner, 1 tranformer)</comments>
 		</contributor>
-		<geographic_location>
-			<latitude>46.2044</latitude>
-			<longitude>6.1432</longitude>
-			<altitude mode="absolute">375</altitude>		  
-		</geographic_location>
+		<coverage>
+  		<geographic_location>
+	  		<latitude>46.2044</latitude>
+		  	<longitude>6.1432</longitude>
+			  <altitude mode="absolute">375</altitude>		  
+		  </geographic_location>
+		</coverage>
 		<created>2024-06-06T13:32:31Z</created>
 		<modified>2024-06-06T13:32:31Z</modified>
 		<unit meter="0.01" name="cm" />

--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -13,9 +13,9 @@
 		<unit meter="0.01" name="cm" />
 		<up_axis>Z_UP</up_axis>
 		<geographic_location>
-			<latitude>46.2044</pv:latitude>
-			<longitude>6.1432</pv:longitude>
-			<altitude mode="absolute">375</pv:elevation>		  
+			<latitude>46.2044</latitude>
+			<longitude>6.1432</longitude>
+			<altitude mode="absolute">375</altitude>		  
 		</geographic_location>
 		<extra>
 			<technique profile="PVCollada-2.0">

--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -10,8 +10,8 @@
 		</contributor>
 		<coverage>
   		<geographic_location>
-	  		<latitude>46.2044</latitude>
 		  	<longitude>6.1432</longitude>
+	  		<latitude>46.2044</latitude>
 			  <altitude mode="absolute">375</altitude>		  
 		  </geographic_location>
 		</coverage>

--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -8,15 +8,15 @@
 			<author>PVsyst</author>
 			<comments>PVC 2.0 sample file : 1 terrain and 3 tables, all based on the same model. Electrical components and circuit (3 inverters, 1 AC combiner, 1 tranformer)</comments>
 		</contributor>
-		<created>2024-06-06T13:32:31Z</created>
-		<modified>2024-06-06T13:32:31Z</modified>
-		<unit meter="0.01" name="cm" />
-		<up_axis>Z_UP</up_axis>
 		<geographic_location>
 			<latitude>46.2044</latitude>
 			<longitude>6.1432</longitude>
 			<altitude mode="absolute">375</altitude>		  
 		</geographic_location>
+		<created>2024-06-06T13:32:31Z</created>
+		<modified>2024-06-06T13:32:31Z</modified>
+		<unit meter="0.01" name="cm" />
+		<up_axis>Z_UP</up_axis>
 		<extra>
 			<technique profile="PVCollada-2.0">
 				<!-- software tag -->

--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -34,7 +34,6 @@
 					<pv:country>CH</pv:country>
 					<pv:timezone>Europe/Zurich</pv:timezone>
 					<pv:timezone_offset>2</pv:timezone_offset>
-					<pv:geocoordinate_system>EPSG:4326</pv:geocoordinate_system>
 					<!-- pv:boundary></pv:boundary -->
 					<pv:module_count>12</pv:module_count>
 					<pv:table_count>3</pv:table_count>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -651,21 +651,6 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
             <xs:documentation xml:lang="en">ISO 3166 country code.</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="latitude" type="xs:float">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">Degrees, positive for north of the equator. Geolocation of the origin of the PV system coordinates</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="longitude" type="xs:float">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">Degrees, positive for east of the prime meridian.  Geolocation of the origin of the PV system coordinates</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="elevation" type="xs:float">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">Meters above mean sea level (MSL).  Geolocation of the origin of the PV system coordinates</xs:documentation>
-          </xs:annotation>
-        </xs:element>
         <xs:element name="timezone" type="xs:string" minOccurs="0">
           <xs:annotation>
             <xs:documentation xml:lang="en">IANA time zone.</xs:documentation>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -662,11 +662,6 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
             1.0</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element name="geocoordinate_system" type="xs:string" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">EPSG code for 3D coordinate system, e.g., WGS-84.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
         <xs:element name="boundary" type="collada:sidref_type" minOccurs="0">
           <xs:annotation>
             <xs:documentation xml:lang="en">ID for a COLLADA geometry describing the project boundary.</xs:documentation>


### PR DESCRIPTION
Closes #23 

COLLADA provides `geographic_location` as a child of any `asset`. COLLADA uses `elevation` rather than `altitude`, which can be `"absolute"` or `"relativeToGround"`.

I think it's better to use the COLLADA elements than to add `extra` elements for geoposition, in case a COLLADA tool is looking for these data.
