### PR TITLE
Add tracker product data model

### DIFF
--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -535,9 +535,11 @@
 				</extra>
 			</instance_geometry>
 			<extra>
+				<!-- data about the table -->
 				<technique profile="PVCollada-2.0">
 					<!-- table tag -->
-					<pv:table>
+					<pv:table id="TableModel1">
+					  <pv:type>fixed</pv:type>
 					</pv:table>
 				</technique>
 			</extra>

--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout_v3.pvc
@@ -538,7 +538,7 @@
 				<!-- data about the table -->
 				<technique profile="PVCollada-2.0">
 					<!-- table tag -->
-					<pv:table id="TableModel1">
+					<pv:table>
 					  <pv:type>fixed</pv:type>
 					</pv:table>
 				</technique>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -957,7 +957,6 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
 					</xs:annotation>
 				</xs:element>
 			</xs:sequence>
-			<xs:attribute name="id" use="required" type="xs:ID" />
 		</xs:complexType>
   </xs:element>
   <xs:element name="post">

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -62,6 +62,18 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:enumeration value="tracker" />
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="tracker_type_enum" final="restriction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="single_axis" />
+      <xs:enumeration value="dual_axis" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="drive_type_enum" final="restriction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="independent" />
+      <xs:enumeration value="linked" />
+    </xs:restriction>
+  </xs:simpleType>
 	<!-- objects for product-level data -->
   <xs:complexType name="module_type_object">
     <xs:annotation>
@@ -468,6 +480,50 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:element name="impedance" type="xs:float" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Impedance, ohm per km</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" use="required" type="xs:ID" />
+  </xs:complexType>
+  <xs:complexType name="tracker_type_object">
+    <xs:annotation>
+      <xs:documentation>Tracker product-level data</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0" />
+      <xs:element name="name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Tracker product name.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="tracker_type" type="xs:tracker_type_enum">
+        <xs:annotation>
+          <xs:documentation>Tracker type (single_axis, dual_axis).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="max_rotation" type="xs:float" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Nominal maximum angle of rotation from horizontal for a single-axis tracker.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="torque_tube_shape" type="torque_tube_shape_enum" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Shape of the torque tube's cross-section for a single-axis tracker.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="torque_tube_diameter" type="xs:float" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Nominal diameter of a single-axis tracker torque tube.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="max_gap_angle" type="xs:float" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Maximum angle of a torque axis formed in a gap between racks on a single-axis tracker.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="drive_type" type="drive_type_enum" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Drive type of a single-axis tracker (independent for a single row, linked for multiple rows).</xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -68,6 +68,13 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:enumeration value="dual_axis" />
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="torque_tube_shape_enum" final="restriction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="circle" />
+      <xs:enumeration value="rectangle" />
+      <xs:enumeration value="octogon" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="drive_type_enum" final="restriction">
     <xs:restriction base="xs:string">
       <xs:enumeration value="independent" />

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -496,7 +496,7 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
           <xs:documentation>Tracker product name.</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="tracker_type" type="xs:tracker_type_enum">
+      <xs:element name="tracker_type" type="tracker_type_enum">
         <xs:annotation>
           <xs:documentation>Tracker type (single_axis, dual_axis).</xs:documentation>
         </xs:annotation>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -61,6 +61,12 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:enumeration value="tracker" />
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="table_type_enum" final="restriction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="fixed tilt" />
+      <xs:enumeration value="tracker" />
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="tracker_type_enum" final="restriction">
     <xs:restriction base="xs:string">
       <xs:enumeration value="single_axis" />
@@ -517,50 +523,6 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     </xs:sequence>
     <xs:attribute name="id" use="required" type="xs:ID" />
   </xs:complexType>
-  <xs:complexType name="tracker_type_object">
-    <xs:annotation>
-      <xs:documentation>Tracker product-level data</xs:documentation>
-    </xs:annotation>
-    <xs:sequence>
-      <xs:element name="manufacturer" type="xs:string" minOccurs="0" />
-      <xs:element name="name" type="xs:string">
-        <xs:annotation>
-          <xs:documentation>Tracker product name.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="tracker_type" type="tracker_type_enum">
-        <xs:annotation>
-          <xs:documentation>Tracker type (single_axis, dual_axis).</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="max_rotation" type="xs:float" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Nominal maximum angle of rotation from horizontal for a single-axis tracker.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="torque_tube_shape" type="torque_tube_shape_enum" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Shape of the torque tube's cross-section for a single-axis tracker.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="torque_tube_diameter" type="xs:float" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Nominal diameter of a single-axis tracker torque tube.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="max_gap_angle" type="xs:float" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Maximum angle of a torque axis formed in a gap between racks on a single-axis tracker.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="drive_type" type="drive_type_enum" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Drive type of a single-axis tracker (independent for a single row, linked for multiple rows).</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-    <xs:attribute name="id" use="required" type="xs:ID" />
-  </xs:complexType>
   <!-- Circuit definition -->
   <xs:complexType name="circuit_type">
     <xs:sequence>
@@ -960,6 +922,43 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
 			The table tag should only appear in the extra/technique section of a Collada node object. The node itself must have one or more instance_geometry
       descendant tags that contain an instance_rack tag.</xs:documentation>
     </xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="type" type="table_type_enum" />
+				<xs:element name="manufacturer" type="xs:string" minOccurs="0" />
+				<xs:element name="tracker_type" type="tracker_type_enum"  minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Tracker type (single_axis, dual_axis).</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tracker_max_rotation" type="xs:float" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Nominal maximum angle of rotation from horizontal for a single-axis tracker.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tracker_torque_tube_shape" type="torque_tube_shape_enum" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Shape of the torque tube's cross-section for a single-axis tracker.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tracker_torque_tube_diameter" type="xs:float" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Nominal diameter of a single-axis tracker torque tube.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tracker_max_gap_angle" type="xs:float" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Maximum angle of a torque axis formed in a gap between racks on a single-axis tracker.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tracker_drive_type" type="drive_type_enum" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Drive type of a single-axis tracker (independent for a single row, linked for multiple rows).</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="id" use="required" type="xs:ID" />
+		</xs:complexType>
   </xs:element>
   <xs:element name="post">
     <xs:annotation>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -63,7 +63,7 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
   </xs:simpleType>
   <xs:simpleType name="table_type_enum" final="restriction">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="fixed tilt" />
+      <xs:enumeration value="fixed" />
       <xs:enumeration value="tracker" />
     </xs:restriction>
   </xs:simpleType>

--- a/schema/pvcollada_schema_0.1.xsd
+++ b/schema/pvcollada_schema_0.1.xsd
@@ -933,7 +933,9 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
 				</xs:element>
 				<xs:element name="tracker_max_rotation" type="xs:float" minOccurs="0">
 					<xs:annotation>
-						<xs:documentation>Nominal maximum angle of rotation from horizontal for a single-axis tracker.</xs:documentation>
+						<xs:documentation>Nominal maximum angle of rotation from horizontal for a single-axis tracker. A pair of values must be provided, e.g., (-45, 45) with the first value being negative.
+						The tracker_azimuth of the associated racks defines the sign of the rotation angle. Rotation is a right-hand rotation around the azimuth axis. 
+						For example, a positive rotation for azimuth=180° is to the west.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="tracker_torque_tube_shape" type="torque_tube_shape_enum" minOccurs="0">


### PR DESCRIPTION
Leaving out maximum angles for two-axis trackers, they are complicated.

instance_tracker deferred to after resolution of #27 