### PR TITLE
Removed mesh_id in transformer and inverter

### DIFF
--- a/schema/pvcollada_schema_2.0.xsd
+++ b/schema/pvcollada_schema_2.0.xsd
@@ -373,11 +373,6 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="mesh_id" type="collada:sidref_type" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Mesh describing inverter object in 3D scene.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
     </xs:sequence>
     <xs:attribute name="id" use="required" type="xs:ID" />
   </xs:complexType>
@@ -469,11 +464,6 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:element name="night_disconnect" type="xs:boolean" minOccurs="0">
         <xs:annotation>
           <xs:documentation>true if the transformer automatically disconnects from the grid at night.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="mesh_id" type="collada:sidref_type" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Mesh describing transformer object in 3D scene.</xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>


### PR DESCRIPTION
Removed mesh_id in transformer and inverter since the link between components/circuit and 3D models/instances is already done in the 3D models/instances part.

Closes #44