### PR TITLE
Split of combiner3d and instance_combiner3d into AC/DC specific tags

### DIFF
--- a/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout.pvc2
+++ b/Examples/05 - VerySimpleFixedPVC2_with_electrical_layout.pvc2
@@ -108,10 +108,10 @@
 					</pv:inverters>
 					<!-- List of AC combiners -->
 					<pv:combiners_ac>
-						<!-- combiner tag -->
-						<pv:combiner_ac id="CombinerModel1">
+						<!-- combiner_ac tag -->
+						<pv:combiner_ac id="CombinerACModel1">
 							<pv:manufacturer>Generic</pv:manufacturer>
-							<pv:name>Generic combiner</pv:name>
+							<pv:name>Generic AC combiner</pv:name>
 							<pv:input_count>3</pv:input_count>
 						</pv:combiner_ac>
 					</pv:combiners_ac>
@@ -166,7 +166,7 @@
 							<pv:cable_to_parent url="#ACCableModel1" length="5" id="cableInstance1" />
 							<pv:inputs>
 								<!-- instance_combiner_ac tag, the AC combiner that will combine the 3 strings -->
-								<pv:instance_combiner_ac url="#CombinerModel1" id="combinerInstance">
+								<pv:instance_combiner_ac url="#CombinerACModel1" id="combinerAcInstance">
 									<!-- Cable between the AC combiner and the transformer -->
 									<pv:cable_to_parent url="#ACCableModel1" length="10" id="cableInstance2" />
 									<!-- inputs tag => the 3 inverters strings -->
@@ -444,27 +444,27 @@
 				</technique>
 			</extra>
 		</geometry>
-		<!-- We define the 3D model for combiners (contains the geometry of the combiner) -->
-		<geometry id="Combiner3DModel">
+		<!-- We define the 3D model for AC combiners (contains the geometry of the AC combiner) -->
+		<geometry id="CombinerAC3DModel">
 			<mesh>
-				<source id="combiner_positions">
-					<float_array id="combiner_positions_array" count="24">
+				<source id="combiner_ac_positions">
+					<float_array id="combiner_ac_positions_array" count="24">
 						-100 -100 0 100 -100 0 100 100 0 -100 100 0
 						-100 -100 120 100 -100 120 100 100 120 -100 100 120
 					</float_array>
 					<technique_common>
-						<accessor source="#combiner_positions_array" count="8" stride="3">
+						<accessor source="#combiner_ac_positions_array" count="8" stride="3">
 							<param name="X" type="float" />
 							<param name="Y" type="float" />
 							<param name="Z" type="float" />
 						</accessor>
 					</technique_common>
 				</source>
-				<vertices id="combiner_vertices">
-					<input semantic="POSITION" source="#combiner_positions" />
+				<vertices id="combiner_ac_vertices">
+					<input semantic="POSITION" source="#combiner_ac_positions" />
 				</vertices>
 				<polygons count="6">
-					<input semantic="VERTEX" source="#combiner_vertices" offset="0" />
+					<input semantic="VERTEX" source="#combiner_ac_vertices" offset="0" />
 					<p>0 1 2 3</p>
 					<p>4 5 6 7</p>
 					<p>0 1 5 4</p>
@@ -475,8 +475,8 @@
 			</mesh>
 			<extra>
 				<technique profile="PVCollada-2.0">
-					<!-- combiner3d tag, references the combiner defined in components -->
-					<pv:combiner3d combiner_id="CombinerModel1" />
+					<!-- combiner_ac3d tag, references the combiner_ac defined in components -->
+					<pv:combiner_ac3d combiner_ac_id="CombinerACModel1" />
 				</technique>
 			</extra>
 		</geometry>
@@ -640,14 +640,14 @@
 					</extra>
 				</instance_geometry>
 			</node>
-			<!-- We instantiate the combiner -->
-			<node id="Combiner3DNode" name="Combiner3DNode" sid="Combiner3DNode">
+			<!-- We instantiate the AC combiner -->
+			<node id="CombinerAC3DNode" name="CombinerAC3DNode" sid="CombinerAC3DNode">
 				<translate>600 -900 0</translate>
-				<instance_geometry url="#Combiner3DModel">
+				<instance_geometry url="#CombinerAC3DModel">
 					<extra>
 						<technique profile="PVCollada-2.0">
-							<!-- instance_combiner3d tag, references the corresponding instance_combiner of the circuit -->
-							<pv:instance_combiner3d instance_combiner_id="combinerInstance" />
+							<!-- instance_combiner_ac3d tag, references the corresponding instance_combiner_ac of the circuit -->
+							<pv:instance_combiner_ac3d instance_combiner_ac_id="combinerAcInstance" />
 						</technique>
 					</extra>
 				</instance_geometry>

--- a/schema/pvcollada_references_2.0.sch
+++ b/schema/pvcollada_references_2.0.sch
@@ -71,14 +71,27 @@
         </rule>
     </pattern>
     
-    <!-- Pattern: Validate instance_combiner3d references -->
-    <pattern id="instance_combiner3d_references">
-        <rule context="pv:instance_combiner3d">
+    <!-- Pattern: Validate instance_combiner_ac3d references -->
+    <pattern id="instance_combiner_ac3d_references">
+        <rule context="pv:instance_combiner_ac3d">
             <let name="instance_geom" value="ancestor::collada:instance_geometry"/>
             <let name="geom_url" value="substring-after($instance_geom/@url, '#')"/>
             <let name="referenced_geom" value="//collada:geometry[@id=$geom_url]"/>
-            <assert test="$referenced_geom//pv:combiner3d">
-                instance_combiner3d must be in an instance_geometry that references a geometry containing a combiner3d element.
+            <assert test="$referenced_geom//pv:combiner_ac3d">
+                instance_combiner_ac3d must be in an instance_geometry that references a geometry containing a combiner_ac3d element.
+                Referenced geometry: <value-of select="$geom_url"/>
+            </assert>
+        </rule>
+    </pattern>
+
+    <!-- Pattern: Validate instance_combiner_dc3d references -->
+    <pattern id="instance_combiner_dc3d_references">
+        <rule context="pv:instance_combiner_dc3d">
+            <let name="instance_geom" value="ancestor::collada:instance_geometry"/>
+            <let name="geom_url" value="substring-after($instance_geom/@url, '#')"/>
+            <let name="referenced_geom" value="//collada:geometry[@id=$geom_url]"/>
+            <assert test="$referenced_geom//pv:combiner_dc3d">
+                instance_combiner_dc3d must be in an instance_geometry that references a geometry containing a combiner_dc3d element.
                 Referenced geometry: <value-of select="$geom_url"/>
             </assert>
         </rule>
@@ -145,13 +158,24 @@
         </rule>
     </pattern>
 	   
-    <!-- Pattern: Validate combiner3d component references -->
-    <pattern id="combiner3d_component_references">
-        <rule context="pv:combiner3d[@combiner_id]">
-            <let name="combiner_ref" value="@combiner_id"/>
-            <assert test="//pv:combiner_ac[@id=$combiner_ref] or //pv:combiner_dc[@id=$combiner_ref]">
-                combiner3d element references non-existent combiner '<value-of select="$combiner_ref"/>'.
-                Must reference a combiner_ac or combiner_dc defined in components.
+    <!-- Pattern: Validate combiner_ac3d component references -->
+    <pattern id="combiner_ac3d_component_references">
+        <rule context="pv:combiner_ac3d[@combiner_ac_id]">
+            <let name="combiner_ac_ref" value="@combiner_ac_id"/>
+            <assert test="//pv:combiner_ac[@id=$combiner_ac_ref]">
+                combiner_ac3d element references non-existent combiner_ac '<value-of select="$combiner_ac_ref"/>'.
+                Must reference a combiner_ac defined in components.
+            </assert>
+        </rule>
+    </pattern>
+	
+    <!-- Pattern: Validate combiner_dc3d component references -->
+    <pattern id="combiner_dc3d_component_references">
+        <rule context="pv:combiner_dc3d[@combiner_dc_id]">
+            <let name="combiner_dc_ref" value="@combiner_dc_id"/>
+            <assert test="//pv:combiner_dc[@id=$combiner_dc_ref]">
+                combiner_dc3d element references non-existent combiner_dc '<value-of select="$combiner_dc_ref"/>'.
+                Must reference a combiner_dc defined in components.
             </assert>
         </rule>
     </pattern>
@@ -189,13 +213,24 @@
         </rule>
     </pattern>
     
-    <!-- Pattern: Validate instance_combiner3d circuit references -->
-    <pattern id="instance_combiner3d_circuit_references">
-        <rule context="pv:instance_combiner3d[@instance_combiner_id]">
-            <let name="instance_ref" value="@instance_combiner_id"/>
-            <assert test="//pv:instance_combiner_ac[@id=$instance_ref] or //pv:instance_combiner_dc[@id=$instance_ref]">
-                instance_combiner3d element references non-existent combiner instance '<value-of select="$instance_ref"/>'.
-                Must reference an instance_combiner_ac or instance_combiner_dc defined in the circuit.
+    <!-- Pattern: Validate instance_combiner_ac3d circuit references -->
+    <pattern id="instance_combiner_ac3d_circuit_references">
+        <rule context="pv:instance_combiner_ac3d[@instance_combiner_ac_id]">
+            <let name="instance_ref" value="@instance_combiner_ac_id"/>
+            <assert test="//pv:instance_combiner_ac[@id=$instance_ref]">
+                instance_combiner_ac3d element references non-existent combiner_ac instance '<value-of select="$instance_ref"/>'.
+                Must reference an instance_combiner_ac defined in the circuit.
+            </assert>
+        </rule>
+    </pattern>
+	
+    <!-- Pattern: Validate instance_combiner_dc3d circuit references -->
+    <pattern id="instance_combiner_dc3d_circuit_references">
+        <rule context="pv:instance_combiner_dc3d[@instance_combiner_dc_id]">
+            <let name="instance_ref" value="@instance_combiner_dc_id"/>
+            <assert test="//pv:instance_combiner_dc[@id=$instance_ref]">
+                instance_combiner_dc3d element references non-existent combiner_dc instance '<value-of select="$instance_ref"/>'.
+                Must reference an instance_combiner_dc defined in the circuit.
             </assert>
         </rule>
     </pattern>

--- a/schema/pvcollada_schema_2.0.xsd
+++ b/schema/pvcollada_schema_2.0.xsd
@@ -1161,29 +1161,56 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="combiner3d">
+  <xs:element name="combiner_ac3d">
     <xs:annotation>
       <xs:documentation>This tag should only appear in the extra/technique section of a Collada geometry tag to signal a 3D model
-      for a combiner.</xs:documentation>
+      for an AC combiner.</xs:documentation>
     </xs:annotation>
     <xs:complexType>
-      <xs:attribute name="combiner_id" type="xs:IDREF">
+      <xs:attribute name="combiner_ac_id" type="xs:IDREF">
         <xs:annotation>
-          <xs:documentation>Id of the combiner defined in the components part</xs:documentation>
+          <xs:documentation>Id of the AC combiner defined in the components part</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>
   </xs:element>
-  <xs:element name="instance_combiner3d">
+  <xs:element name="instance_combiner_ac3d">
     <xs:annotation>
       <xs:documentation>This tag should only appear in the extra/technique section of a Collada instance_geometry tag to signal a
-      3D instance of a combiner. The attribute url of the instance_geometry must reference a Collada geometry that is a model for a
-      combiner3d (has an combiner3d tag in its extra/technique tag).</xs:documentation>
+      3D instance of an AC combiner. The attribute url of the instance_geometry must reference a Collada geometry that is a model
+	  for a combiner_ac3d (has an combiner_ac3d tag in its extra/technique tag).</xs:documentation>
     </xs:annotation>
     <xs:complexType>
-      <xs:attribute name="instance_combiner_id" type="xs:IDREF">
+      <xs:attribute name="instance_combiner_ac_id" type="xs:IDREF">
         <xs:annotation>
-          <xs:documentation>Id of the instance_combiner defined in the circuit part</xs:documentation>
+          <xs:documentation>Id of the instance_combiner_ac defined in the circuit part</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="combiner_dc3d">
+    <xs:annotation>
+      <xs:documentation>This tag should only appear in the extra/technique section of a Collada geometry tag to signal a 3D model
+      for an DC combiner.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="combiner_dc_id" type="xs:IDREF">
+        <xs:annotation>
+          <xs:documentation>Id of the DC combiner defined in the components part</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="instance_combiner_dc3d">
+    <xs:annotation>
+      <xs:documentation>This tag should only appear in the extra/technique section of a Collada instance_geometry tag to signal a
+      3D instance of an DC combiner. The attribute url of the instance_geometry must reference a Collada geometry that is a model
+	  for a combiner_dc3d (has an combiner_dc3d tag in its extra/technique tag).</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="instance_combiner_dc_id" type="xs:IDREF">
+        <xs:annotation>
+          <xs:documentation>Id of the instance_combiner_dc defined in the circuit part</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>

--- a/schema/pvcollada_structure_2.0.sch
+++ b/schema/pvcollada_structure_2.0.sch
@@ -64,11 +64,21 @@
             </assert>
         </rule>
     </pattern>
+
+	<!-- Pattern: Validate only known PVCollada elements in asset -->
+	<pattern id="valid_asset_pvcollada_elements">
+		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:asset]/pv:*">
+			<assert test="self::pv:software or self::pv:project or self::pv:components or self::pv:circuit">
+				Unknown PVCollada element '<name/>' in asset technique. 
+				Allowed elements: software, project, components, circuit.
+			</assert>
+		</rule>
+	</pattern>
     
     <!-- Pattern: Geometry-level PVCollada elements placement -->
     <pattern id="geometry_pvcollada_placement">
         <rule context="pv:terrain | pv:rack | pv:post | pv:gap | 
-                      pv:inverter3d | pv:combiner3d | pv:transformer3d | pv:cable3d">
+                      pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:transformer3d | pv:cable3d">
             <assert test="parent::collada:technique/parent::collada:extra/parent::collada:geometry">
                 Element '<name/>' must be inside geometry/extra/technique
             </assert>
@@ -79,18 +89,30 @@
     <pattern id="geometry_unique_elements">
         <rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:geometry]">
             <assert test="count(pv:terrain | pv:rack | pv:post | pv:gap | 
-                               pv:inverter3d | pv:combiner3d | pv:transformer3d | pv:cable3d) &lt;= 1">
-                Only one terrain, rack, post, gap, inverter3d, combiner3d, transformer3d or cable3d element is allowed per geometry. 
+                               pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:transformer3d | pv:cable3d) &lt;= 1">
+                Only one terrain, rack, post, gap, inverter3d, combiner_ac3d, combiner_dc3d, transformer3d or cable3d element is allowed per geometry. 
                 Found <value-of select="count(pv:terrain | pv:rack | pv:post | pv:gap | 
-                                            pv:inverter3d | pv:combiner3d | pv:transformer3d | pv:cable3d)"/> elements.
+                                            pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:transformer3d | pv:cable3d)"/> elements.
             </assert>
         </rule>
     </pattern>
+
+	<!-- Pattern: Validate only known PVCollada elements in geometry -->
+	<pattern id="valid_geometry_pvcollada_elements">
+		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:geometry]/pv:*">
+			<assert test="self::pv:terrain or self::pv:rack or self::pv:post or self::pv:gap or 
+						  self::pv:inverter3d or self::pv:combiner_ac3d or self::pv:combiner_dc3d or 
+						  self::pv:transformer3d or self::pv:cable3d">
+				Unknown PVCollada element '<name/>' in geometry technique. 
+				Allowed elements: terrain, rack, post, gap, inverter3d, combiner_ac3d, combiner_dc3d, transformer3d, cable3d.
+			</assert>
+		</rule>
+	</pattern>
     
     <!-- Pattern: Instance_geometry-level PVCollada elements placement -->
     <pattern id="instance_geometry_pvcollada_placement">
         <rule context="pv:instance_terrain | pv:instance_rack | pv:instance_post | pv:instance_gap | 
-                      pv:instance_inverter3d | pv:instance_combiner3d | pv:instance_transformer3d | pv:instance_cable3d">
+                      pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | pv:instance_transformer3d | pv:instance_cable3d">
             <assert test="parent::collada:technique/parent::collada:extra/parent::collada:instance_geometry">
                 Element '<name/>' must be inside instance_geometry/extra/technique
             </assert>
@@ -101,13 +123,25 @@
     <pattern id="instance_geometry_unique_elements">
         <rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:instance_geometry]">
             <assert test="count(pv:instance_terrain | pv:instance_rack | pv:instance_post | pv:instance_gap | 
-                               pv:instance_inverter3d | pv:instance_combiner3d | pv:instance_transformer3d | pv:instance_cable3d) &lt;= 1">
-                Only one instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner3d, instance_transformer3d or pv:instance_cable3d element is allowed per instance_geometry. 
+                               pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | pv:instance_transformer3d | pv:instance_cable3d) &lt;= 1">
+                Only one instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner_ac3d, instance_combiner_dc3d, instance_transformer3d or pv:instance_cable3d element is allowed per instance_geometry. 
                 Found <value-of select="count(pv:instance_terrain |  pv:instance_rack | pv:instance_post | pv:instance_gap | 
-                                            pv:instance_inverter3d | pv:instance_combiner3d | pv:instance_transformer3d | pv:instance_cable3d)"/> elements.
+                                            pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | pv:instance_transformer3d | pv:instance_cable3d)"/> elements.
             </assert>
         </rule>
     </pattern>
+
+	<!-- Pattern: Validate only known PVCollada elements in instance_geometry -->
+	<pattern id="valid_instance_geometry_pvcollada_elements">
+		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:instance_geometry]/pv:*">
+			<assert test="self::pv:instance_terrain or self::pv:instance_rack or self::pv:instance_post or self::pv:instance_gap or 
+						  self::pv:instance_inverter3d or self::pv:instance_combiner_ac3d or self::pv:instance_combiner_dc3d or 
+						  self::pv:instance_transformer3d or self::pv:instance_cable3d">
+				Unknown PVCollada element '<name/>' in instance_geometry technique. 
+				Allowed elements: instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner_ac3d, instance_combiner_dc3d, instance_transformer3d, instance_cable3d.
+			</assert>
+		</rule>
+	</pattern>
     
     <!-- Pattern: Node-level PVCollada elements placement -->
     <pattern id="node_pvcollada_placement">
@@ -126,6 +160,16 @@
             </assert>
         </rule>
     </pattern>
+	
+	<!-- Pattern: Validate only known PVCollada elements in node -->
+	<pattern id="valid_node_pvcollada_elements">
+		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:node]/pv:*">
+			<assert test="self::pv:table">
+				Unknown PVCollada element '<name/>' in node technique. 
+				Allowed elements: table.
+			</assert>
+		</rule>
+	</pattern>
     
     <!-- Pattern: Instance_node-level PVCollada elements placement -->
     <pattern id="instance_node_pvcollada_placement">
@@ -144,6 +188,16 @@
             </assert>
         </rule>
     </pattern>
+
+	<!-- Pattern: Validate only known PVCollada elements in instance_node -->
+	<pattern id="valid_instance_node_pvcollada_elements">
+		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:instance_node]/pv:*">
+			<assert test="self::pv:instance_table">
+				Unknown PVCollada element '<name/>' in instance_node technique. 
+				Allowed elements: instance_table.
+			</assert>
+		</rule>
+	</pattern>
     
     <!-- Pattern: Ensure table nodes contain rack instances -->
     <pattern id="table_must_contain_racks">


### PR DESCRIPTION
- Split of `combiner3d` into `combiner_ac3d` and `combiner_dc3d`
- Split of `instance_combiner3d` into `instance_combiner_ac3d` and `instance_combiner_dc3d`
- Adjusted schematron rules
- Added schematron rule to reject any tags not defined in the PVC 2.0 schema
- Adjusted example file

Closes #49