### PR TITLE
Relates to #50

### DIFF
--- a/schema/pvcollada_references_2.0.sch
+++ b/schema/pvcollada_references_2.0.sch
@@ -96,6 +96,19 @@
             </assert>
         </rule>
     </pattern>
+
+    <!-- Pattern: Validate instance_optimizer3d references -->
+    <pattern id="instance_optimizer3d_references">
+        <rule context="pv:instance_optimizer3d">
+            <let name="instance_geom" value="ancestor::collada:instance_geometry"/>
+            <let name="geom_url" value="substring-after($instance_geom/@url, '#')"/>
+            <let name="referenced_geom" value="//collada:geometry[@id=$geom_url]"/>
+            <assert test="$referenced_geom//pv:optimizer3d">
+                instance_optimizer3d must be in an instance_geometry that references a geometry containing an optimizer3d element.
+                Referenced geometry: <value-of select="$geom_url"/>
+            </assert>
+        </rule>
+    </pattern>
     
     <!-- Pattern: Validate instance_transformer3d references -->
     <pattern id="instance_transformer3d_references">
@@ -179,6 +192,17 @@
             </assert>
         </rule>
     </pattern>
+
+    <!-- Pattern: Validate optimizer3d component references -->
+    <pattern id="optimizer3d_component_references">
+        <rule context="pv:optimizer3d[@optimizer_id]">
+            <let name="optimizer_ref" value="@optimizer_id"/>
+            <assert test="//pv:optimizer[@id=$optimizer_ref]">
+                optimzer3d element references non-existent optimizer '<value-of select="$optimizer_ref"/>'.
+                Must reference an optimizer defined in components/optimizers.
+            </assert>
+        </rule>
+    </pattern>
     
     <!-- Pattern: Validate cable3d component references -->
     <pattern id="cable3d_component_references">
@@ -231,6 +255,17 @@
             <assert test="//pv:instance_combiner_dc[@id=$instance_ref]">
                 instance_combiner_dc3d element references non-existent combiner_dc instance '<value-of select="$instance_ref"/>'.
                 Must reference an instance_combiner_dc defined in the circuit.
+            </assert>
+        </rule>
+    </pattern>
+	
+    <!-- Pattern: Validate instance_optimizer3d circuit references -->
+    <pattern id="instance_optimizer3d_circuit_references">
+        <rule context="pv:instance_optimizer3d[@instance_optimizer_id]">
+            <let name="instance_ref" value="@instance_optimizer_id"/>
+            <assert test="//pv:instance_optimizer[@id=$instance_ref]">
+                instance_optimizer3d element references non-existent optimizer instance '<value-of select="$instance_ref"/>'.
+                Must reference an instance_optimizer defined in the circuit.
             </assert>
         </rule>
     </pattern>
@@ -306,6 +341,17 @@
             <assert test="//pv:combiner_dc[@id=$component_ref]">
                 instance_combiner_dc references non-existent combiner_dc component '<value-of select="@url"/>'.
                 Must reference a combiner_dc defined in components/combiners_dc.
+            </assert>
+        </rule>
+    </pattern>
+
+    <!-- Pattern: Validate instance_optimizer URL references -->
+    <pattern id="instance_optimizer_url_references">
+        <rule context="pv:instance_optimizer[@url]">
+            <let name="component_ref" value="substring-after(@url, '#')"/>
+            <assert test="//pv:optimizer[@id=$component_ref]">
+                instance_optimizer references non-existent optimizer component '<value-of select="@url"/>'.
+                Must reference an optimizer defined in components/optimizers.
             </assert>
         </rule>
     </pattern>

--- a/schema/pvcollada_schema_2.0.xsd
+++ b/schema/pvcollada_schema_2.0.xsd
@@ -414,6 +414,24 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     </xs:sequence>
     <xs:attribute name="id" use="required" type="xs:ID" />
   </xs:complexType>
+  <xs:complexType name="optimizer_type_object">
+    <xs:annotation>
+      <xs:documentation>Optimizer product-level data</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="manufacturer" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Optimizer manufacturer name.</xs:documentation>
+        </xs:annotation>  
+	  </xs:element>
+      <xs:element name="name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optimizer model name.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" use="required" type="xs:ID" />
+  </xs:complexType>
   <xs:complexType name="transformer_type_object">
     <xs:annotation>
       <xs:documentation>Transformer product-level data</xs:documentation>
@@ -626,7 +644,11 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       </xs:choice>
       <xs:element name="inputs" type="optimizer_inputs_type" />
     </xs:sequence>
-    <xs:attribute name="url" type="xs:string" use="required" />
+    <xs:attribute name="url" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Contains # followed by the id of the optimizer model defined in the components part</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="id" type="xs:ID" use="required" />
     <xs:attribute name="name" type="xs:string" use="optional" />
   </xs:complexType>
@@ -804,6 +826,13 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="combiner_dc" type="combiner_dc_type_object" maxOccurs="unbounded" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="optimizers" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="optimizer" type="optimizer_type_object" maxOccurs="unbounded" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -1240,6 +1269,38 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:attribute name="instance_combiner_dc_id" type="xs:IDREF">
         <xs:annotation>
           <xs:documentation>Id of the instance_combiner_dc defined in the circuit part</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="optimizer3d">
+    <xs:annotation>
+      <xs:documentation>This tag should only appear in the extra/technique section of a Collada geometry tag to signal a 3D model
+      for an optimizer.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="optimizer_id" type="xs:IDREF">
+        <xs:annotation>
+          <xs:documentation>Id of the optimizer defined in the components part</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="instance_optimizer3d">
+    <xs:annotation>
+      <xs:documentation>This tag should only appear in the extra/technique section of a Collada instance_geometry tag to signal a
+      3D instance of an optimizer. The attribute url of the instance_geometry must reference a Collada geometry that is a model
+	  for an optimizer3d (has an optimizer3d tag in its extra/technique tag).</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="id" use="required" type="xs:ID">
+        <xs:annotation>
+          <xs:documentation>Unique id for the optimizer3d instance</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="instance_optimizer_id" type="xs:IDREF">
+        <xs:annotation>
+          <xs:documentation>Id of the instance_optimizer defined in the circuit part</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>

--- a/schema/pvcollada_structure_2.0.sch
+++ b/schema/pvcollada_structure_2.0.sch
@@ -78,7 +78,7 @@
     <!-- Pattern: Geometry-level PVCollada elements placement -->
     <pattern id="geometry_pvcollada_placement">
         <rule context="pv:terrain | pv:rack | pv:post | pv:gap | 
-                      pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:transformer3d | pv:cable3d">
+                      pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:optimizer3d | pv:transformer3d | pv:cable3d">
             <assert test="parent::collada:technique/parent::collada:extra/parent::collada:geometry">
                 Element '<name/>' must be inside geometry/extra/technique
             </assert>
@@ -89,10 +89,10 @@
     <pattern id="geometry_unique_elements">
         <rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:geometry]">
             <assert test="count(pv:terrain | pv:rack | pv:post | pv:gap | 
-                               pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:transformer3d | pv:cable3d) &lt;= 1">
-                Only one terrain, rack, post, gap, inverter3d, combiner_ac3d, combiner_dc3d, transformer3d or cable3d element is allowed per geometry. 
+                               pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:optimizer3d | pv:transformer3d | pv:cable3d) &lt;= 1">
+                Only one terrain, rack, post, gap, inverter3d, combiner_ac3d, combiner_dc3d, optimizer3d transformer3d or cable3d element is allowed per geometry. 
                 Found <value-of select="count(pv:terrain | pv:rack | pv:post | pv:gap | 
-                                            pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:transformer3d | pv:cable3d)"/> elements.
+                                            pv:inverter3d | pv:combiner_ac3d | pv:combiner_dc3d | pv:optimizer3d | pv:transformer3d | pv:cable3d)"/> elements.
             </assert>
         </rule>
     </pattern>
@@ -101,10 +101,10 @@
 	<pattern id="valid_geometry_pvcollada_elements">
 		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:geometry]/pv:*">
 			<assert test="self::pv:terrain or self::pv:rack or self::pv:post or self::pv:gap or 
-						  self::pv:inverter3d or self::pv:combiner_ac3d or self::pv:combiner_dc3d or 
-						  self::pv:transformer3d or self::pv:cable3d">
+						  self::pv:inverter3d or self::pv:combiner_ac3d or self::pv:combiner_dc3d or
+                          self::pv:optimizer3d or self::pv:transformer3d or self::pv:cable3d">
 				Unknown PVCollada element '<name/>' in geometry technique. 
-				Allowed elements: terrain, rack, post, gap, inverter3d, combiner_ac3d, combiner_dc3d, transformer3d, cable3d.
+				Allowed elements: terrain, rack, post, gap, inverter3d, combiner_ac3d, combiner_dc3d, optimizer3d, transformer3d, cable3d.
 			</assert>
 		</rule>
 	</pattern>
@@ -112,7 +112,8 @@
     <!-- Pattern: Instance_geometry-level PVCollada elements placement -->
     <pattern id="instance_geometry_pvcollada_placement">
         <rule context="pv:instance_terrain | pv:instance_rack | pv:instance_post | pv:instance_gap | 
-                      pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | pv:instance_transformer3d | pv:instance_cable3d">
+                      pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | 
+					  pv:instance_optimizer3d | pv:instance_transformer3d | pv:instance_cable3d">
             <assert test="parent::collada:technique/parent::collada:extra/parent::collada:instance_geometry">
                 Element '<name/>' must be inside instance_geometry/extra/technique
             </assert>
@@ -123,10 +124,12 @@
     <pattern id="instance_geometry_unique_elements">
         <rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:instance_geometry]">
             <assert test="count(pv:instance_terrain | pv:instance_rack | pv:instance_post | pv:instance_gap | 
-                               pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | pv:instance_transformer3d | pv:instance_cable3d) &lt;= 1">
-                Only one instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner_ac3d, instance_combiner_dc3d, instance_transformer3d or pv:instance_cable3d element is allowed per instance_geometry. 
+                               pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | 
+							   pv:instance_optimizer3d | pv:instance_transformer3d | pv:instance_cable3d) &lt;= 1">
+                Only one instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner_ac3d, instance_combiner_dc3d,instance_optimizer3d, instance_transformer3d or pv:instance_cable3d element is allowed per instance_geometry. 
                 Found <value-of select="count(pv:instance_terrain |  pv:instance_rack | pv:instance_post | pv:instance_gap | 
-                                            pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | pv:instance_transformer3d | pv:instance_cable3d)"/> elements.
+                                            pv:instance_inverter3d | pv:instance_combiner_ac3d | pv:instance_combiner_dc3d | 
+											pv:instance_optimizer3d | pv:instance_transformer3d | pv:instance_cable3d)"/> elements.
             </assert>
         </rule>
     </pattern>
@@ -136,9 +139,9 @@
 		<rule context="collada:technique[@profile='PVCollada-2.0'][parent::collada:extra/parent::collada:instance_geometry]/pv:*">
 			<assert test="self::pv:instance_terrain or self::pv:instance_rack or self::pv:instance_post or self::pv:instance_gap or 
 						  self::pv:instance_inverter3d or self::pv:instance_combiner_ac3d or self::pv:instance_combiner_dc3d or 
-						  self::pv:instance_transformer3d or self::pv:instance_cable3d">
+						  self::pv:instance_optimizer3d or self::pv:instance_transformer3d or self::pv:instance_cable3d">
 				Unknown PVCollada element '<name/>' in instance_geometry technique. 
-				Allowed elements: instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner_ac3d, instance_combiner_dc3d, instance_transformer3d, instance_cable3d.
+				Allowed elements: instance_terrain, instance_rack, instance_post, instance_gap, instance_inverter3d, instance_combiner_ac3d, instance_combiner_dc3d, instance_optimizer3d, instance_transformer3d, instance_cable3d.
 			</assert>
 		</rule>
 	</pattern>


### PR DESCRIPTION
Initial version for #50:
- Created optimizers object in the components part
- Created optimizer object in the components part, with just manufacturer and name fields. Additional fields will need to be added once the group agrees on the set
- Created optimizer3d and instance_optimizer3d objects in the 3D part
- Added schematron validation rules for the new objects