### PR TITLE
Correct type for tracker_max_rotation

### DIFF
--- a/schema/pvcollada_schema_2.0.xsd
+++ b/schema/pvcollada_schema_2.0.xsd
@@ -972,7 +972,7 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
 						<xs:documentation>Tracker type (single_axis, dual_axis).</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="tracker_max_rotation" type="xs:float" minOccurs="0">
+				<xs:element name="tracker_max_rotation" type="collada:float2_type" minOccurs="0">
 					<xs:annotation>
 						<xs:documentation>Nominal maximum angle of rotation from horizontal for a single-axis tracker. A pair of values must be provided, e.g., (-45, 45) with the first value being negative.
 						The tracker_azimuth of the associated racks defines the sign of the rotation angle. Rotation is a right-hand rotation around the azimuth axis. 


### PR DESCRIPTION
Closes #61

Changed type of `tracker_max_rotation` from `xs:float` to `collada:float2_type`