### PR TITLE
Create module_architecture

### DIFF
--- a/schema/PVCollada_2.0/pvcollada_schema_2.0.xsd
+++ b/schema/PVCollada_2.0/pvcollada_schema_2.0.xsd
@@ -38,6 +38,10 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
     <xs:restriction base="xs:string">
       <xs:enumeration value="monofacial" />
       <xs:enumeration value="bifacial" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="module_architecture_enum" final="restriction">
+    <xs:restriction base="xs:string">
       <xs:enumeration value="cpv" />
       <xs:enumeration value="shingle" />
     </xs:restriction>
@@ -127,6 +131,11 @@ xmlns:collada="http://www.collada.org/2008/03/COLLADASchema">
       <xs:element name="module_type" type="module_type_enum" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Module type.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="module_architecture" type="module_architecture_enum" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Module architecture.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="nom_power" type="xs:float">


### PR DESCRIPTION
Split the current <module_type> enumeration into two:
- <module_type> is monofacial, bifacial
- <module_architecture> has cpv, shingle, can be extended for other terms describing module assembly.

All examples currently use module_type=bifacial so the only change is to the schema.