### PR TITLE
Validation of mode attribute for altitude tag

### DIFF
--- a/schema/PVCollada_2.0/pvcollada_structure_2.0.sch
+++ b/schema/PVCollada_2.0/pvcollada_structure_2.0.sch
@@ -37,6 +37,18 @@
 			</assert>
 		</rule>
 	</pattern>
+	
+	<!-- Pattern: Ensure altitude mode is absolute -->
+	<pattern id="altitude_mode_requirement">
+		<rule context="collada:altitude">
+			<assert test="@mode">
+				altitude element must have a 'mode' attribute
+			</assert>
+			<assert test="not(@mode) or @mode = 'absolute'">
+				altitude 'mode' attribute must have value 'absolute'. Found '<value-of select="@mode"/>'
+			</assert>
+		</rule>
+	</pattern>
     
     <!-- Pattern: Asset-level PVCollada elements placement -->
     <pattern id="asset_pvcollada_placement">


### PR DESCRIPTION
If "altitude" tag is present in the PVC2 file, it should contain "mode" attribute with value "absolute"